### PR TITLE
Make Rending Plinth work interdimensionally

### DIFF
--- a/src/main/java/dev/hyperlynx/reactive/Registration.java
+++ b/src/main/java/dev/hyperlynx/reactive/Registration.java
@@ -8,7 +8,6 @@ import dev.hyperlynx.reactive.alchemy.rxn.ReactionMan;
 import dev.hyperlynx.reactive.alchemy.special.SpecialCaseMan;
 import dev.hyperlynx.reactive.be.*;
 import dev.hyperlynx.reactive.blocks.*;
-import dev.hyperlynx.reactive.client.gui.LitmusScreen;
 import dev.hyperlynx.reactive.client.gui.LitmusScreenOpener;
 import dev.hyperlynx.reactive.client.gui.LitmusScreenPayload;
 import dev.hyperlynx.reactive.cmd.PowerArgumentInfo;
@@ -69,8 +68,6 @@ import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.network.event.RegisterConfigurationTasksEvent;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
-import net.neoforged.neoforge.network.handling.IPayloadContext;
-import net.neoforged.neoforge.network.handling.IPayloadHandler;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -128,7 +125,7 @@ public class Registration {
             () -> new BlockItem(SHULKER_CRUCIBLE.get(), new Item.Properties()));
 
     // Register the Crucible BE.
-    public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<CrucibleBlockEntity>> CRUCIBLE_BE_TYPE = BLOCK_ENTITY_TYPES.register("crucible_be",
+    public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<CrucibleBlockEntity>> CRUCIBLE_BE = BLOCK_ENTITY_TYPES.register("crucible_be",
             () -> BlockEntityType.Builder.of(CrucibleBlockEntity::new, CRUCIBLE.get(), SHULKER_CRUCIBLE.get()).build(null));
 
     // Register the rest of the blocks
@@ -157,7 +154,7 @@ public class Registration {
     public static final DeferredHolder<Item, SymbolItem> DIVINE_SYMBOL_ITEM = SymbolItem.registerSimpleBlockItem(DIVINE_SYMBOL);
 
     // Register the Symbol BE
-    public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<SymbolBlockEntity>> SYMBOL_BE_TYPE = BLOCK_ENTITY_TYPES.register("symbol_be",
+    public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<SymbolBlockEntity>> SYMBOL_BE = BLOCK_ENTITY_TYPES.register("symbol_be",
             () -> BlockEntityType.Builder.of(SymbolBlockEntity::new, COPPER_SYMBOL.get(), IRON_SYMBOL.get(), GOLD_SYMBOL.get(), OCCULT_SYMBOL.get(), DIVINE_SYMBOL.get()).build(null));
 
     public static final DeferredHolder<Block, BlazeRodBlock> BLAZE_ROD = BLOCKS.register("blaze_rod",
@@ -380,7 +377,7 @@ public class Registration {
     public static final DeferredHolder<Block, GatewayBlock> GATEWAY_BLOCK = BLOCKS.register("gateway",
             () -> new GatewayBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.END_GATEWAY)));
 
-    public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<GatewayBlockEntity>> GATEWAY_BLOCK_ENTITY = BLOCK_ENTITY_TYPES.register("gateway_be",
+    public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<GatewayBlockEntity>> GATEWAY_BE = BLOCK_ENTITY_TYPES.register("gateway_be",
             () -> BlockEntityType.Builder.of(GatewayBlockEntity::new, GATEWAY_BLOCK.get()).build(null));
 
     // Register items.

--- a/src/main/java/dev/hyperlynx/reactive/Registration.java
+++ b/src/main/java/dev/hyperlynx/reactive/Registration.java
@@ -377,6 +377,12 @@ public class Registration {
                     .emissiveRendering((a, b, c) -> true)
                     .pushReaction(PushReaction.DESTROY)));
 
+    public static final DeferredHolder<Block, GatewayBlock> GATEWAY_BLOCK = BLOCKS.register("gateway",
+            () -> new GatewayBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.END_GATEWAY)));
+
+    public static final DeferredHolder<BlockEntityType<?>, BlockEntityType<GatewayBlockEntity>> GATEWAY_BLOCK_ENTITY = BLOCK_ENTITY_TYPES.register("gateway_be",
+            () -> BlockEntityType.Builder.of(GatewayBlockEntity::new, GATEWAY_BLOCK.get()).build(null));
+
     // Register items.
     public static final DeferredHolder<Item, VortexStoneItem> VORTEX_STONE = ITEMS.register("vortex_stone",
             () -> new VortexStoneItem(new Item.Properties()

--- a/src/main/java/dev/hyperlynx/reactive/be/CrucibleBlockEntity.java
+++ b/src/main/java/dev/hyperlynx/reactive/be/CrucibleBlockEntity.java
@@ -101,7 +101,7 @@ public class CrucibleBlockEntity extends BlockEntity implements Reactor {
     public List<ReactionStatusEntry> reaction_status = new ArrayList<>(); // Reaction state of the previous tick. Only updated on the server. Used by Litmus Paper.
 
     public CrucibleBlockEntity(BlockPos pos, BlockState state) {
-        super(Registration.CRUCIBLE_BE_TYPE.get(), pos, state);
+        super(Registration.CRUCIBLE_BE.get(), pos, state);
         NeoForge.EVENT_BUS.register(this);
         areaMemory = new AreaMemory(pos);
     }

--- a/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
+++ b/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
@@ -1,5 +1,6 @@
 package dev.hyperlynx.reactive.be;
 
+import dev.hyperlynx.reactive.ReactiveMod;
 import dev.hyperlynx.reactive.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -7,6 +8,7 @@ import net.minecraft.core.GlobalPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.IntTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.resources.ResourceKey;
@@ -17,6 +19,7 @@ import net.minecraft.world.level.block.entity.TheEndPortalBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.Optional;
+import java.util.Random;
 
 public class GatewayBlockEntity extends TheEndPortalBlockEntity {
     private int tick_count;
@@ -26,6 +29,8 @@ public class GatewayBlockEntity extends TheEndPortalBlockEntity {
 
     public GatewayBlockEntity(BlockPos pos, BlockState blockState) {
         super(Registration.GATEWAY_BE.get(), pos, blockState);
+        Random random = new Random(pos.hashCode());
+        tick_count = random.nextInt(0, 12000);
     }
 
     @Override
@@ -33,8 +38,10 @@ public class GatewayBlockEntity extends TheEndPortalBlockEntity {
         return true;
     }
 
-    public static <T extends BlockEntity> void tick(Level level, BlockPos blockPos, BlockState blockState, T gateway) {
-        ((GatewayBlockEntity) gateway).tick_count++;
+    public static <T extends BlockEntity> void tick(Level level, BlockPos blockPos, BlockState blockState, T t) {
+        if(level.isClientSide() && t instanceof GatewayBlockEntity gateway){
+            gateway.tick_count++;
+        }
     }
 
     public float totalTick(float partialTick) {

--- a/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
+++ b/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
@@ -3,13 +3,26 @@ package dev.hyperlynx.reactive.be;
 import dev.hyperlynx.reactive.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.GlobalPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.TheEndPortalBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
+import java.util.Optional;
+
 public class GatewayBlockEntity extends TheEndPortalBlockEntity {
     private int tick_count;
+    public GlobalPos target;
+    private final String TARGET_POS_TAG = "Target";
+    private final String TARGET_DIMENSION_TAG = "Dimension";
 
     public GatewayBlockEntity(BlockPos pos, BlockState blockState) {
         super(Registration.GATEWAY_BE.get(), pos, blockState);
@@ -26,5 +39,24 @@ public class GatewayBlockEntity extends TheEndPortalBlockEntity {
 
     public float totalTick(float partialTick) {
         return (float) tick_count + partialTick;
+    }
+
+    @Override
+    protected void saveAdditional(CompoundTag tag, HolderLookup.Provider registries) {
+        super.saveAdditional(tag, registries);
+        if(this.target == null)
+            return;
+        tag.put(TARGET_POS_TAG, NbtUtils.writeBlockPos(target.pos()));
+        tag.put(TARGET_DIMENSION_TAG, StringTag.valueOf(String.valueOf(target.dimension().location())));
+    }
+
+    @Override
+    protected void loadAdditional(CompoundTag tag, HolderLookup.Provider registries) {
+        super.loadAdditional(tag, registries);
+        Optional<BlockPos> pos = NbtUtils.readBlockPos(tag, TARGET_POS_TAG);
+        if(pos.isEmpty())
+            return;
+        ResourceLocation location = ResourceLocation.parse(tag.get(TARGET_DIMENSION_TAG).getAsString());
+        target = GlobalPos.of(ResourceKey.create(Registries.DIMENSION, location), pos.get());
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
+++ b/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
@@ -2,12 +2,17 @@ package dev.hyperlynx.reactive.be;
 
 import dev.hyperlynx.reactive.Registration;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.entity.TheEndPortalBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
-public class GatewayBlockEntity extends BlockEntity {
+public class GatewayBlockEntity extends TheEndPortalBlockEntity {
     public GatewayBlockEntity(BlockPos pos, BlockState blockState) {
-        super(Registration.GATEWAY_BLOCK_ENTITY.get(), pos, blockState);
+        super(Registration.GATEWAY_BE.get(), pos, blockState);
+    }
+
+    @Override
+    public boolean shouldRenderFace(Direction face) {
+        return true;
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
+++ b/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
@@ -3,10 +3,14 @@ package dev.hyperlynx.reactive.be;
 import dev.hyperlynx.reactive.Registration;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.TheEndPortalBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class GatewayBlockEntity extends TheEndPortalBlockEntity {
+    private int tick_count;
+
     public GatewayBlockEntity(BlockPos pos, BlockState blockState) {
         super(Registration.GATEWAY_BE.get(), pos, blockState);
     }
@@ -14,5 +18,13 @@ public class GatewayBlockEntity extends TheEndPortalBlockEntity {
     @Override
     public boolean shouldRenderFace(Direction face) {
         return true;
+    }
+
+    public static <T extends BlockEntity> void tick(Level level, BlockPos blockPos, BlockState blockState, T gateway) {
+        ((GatewayBlockEntity) gateway).tick_count++;
+    }
+
+    public float totalTick(float partialTick) {
+        return (float) tick_count + partialTick;
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
+++ b/src/main/java/dev/hyperlynx/reactive/be/GatewayBlockEntity.java
@@ -1,0 +1,13 @@
+package dev.hyperlynx.reactive.be;
+
+import dev.hyperlynx.reactive.Registration;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class GatewayBlockEntity extends BlockEntity {
+    public GatewayBlockEntity(BlockPos pos, BlockState blockState) {
+        super(Registration.GATEWAY_BLOCK_ENTITY.get(), pos, blockState);
+    }
+}

--- a/src/main/java/dev/hyperlynx/reactive/be/SymbolBlockEntity.java
+++ b/src/main/java/dev/hyperlynx/reactive/be/SymbolBlockEntity.java
@@ -30,13 +30,13 @@ public class SymbolBlockEntity extends BlockEntity {
     public Item symbol_item = Items.BARRIER;
 
     public SymbolBlockEntity(BlockPos pos, BlockState state, Item item) {
-        super(Registration.SYMBOL_BE_TYPE.get(), pos, state);
+        super(Registration.SYMBOL_BE.get(), pos, state);
         NeoForge.EVENT_BUS.register(this);
         setItem(item);
     }
 
     public SymbolBlockEntity(BlockPos pos, BlockState state) {
-        super(Registration.SYMBOL_BE_TYPE.get(), pos, state);
+        super(Registration.SYMBOL_BE.get(), pos, state);
     }
 
     public void setFacing(Direction facing) {

--- a/src/main/java/dev/hyperlynx/reactive/blocks/CrucibleBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/CrucibleBlock.java
@@ -318,7 +318,7 @@ public class CrucibleBlock extends CrucibleShapedBlock implements EntityBlock, W
     @Nullable
     @Override
     public <CrucibleBlockEntity extends BlockEntity> BlockEntityTicker<CrucibleBlockEntity> getTicker(Level level, BlockState state, BlockEntityType<CrucibleBlockEntity> type) {
-       if(type == Registration.CRUCIBLE_BE_TYPE.get()){
+       if(type == Registration.CRUCIBLE_BE.get()){
            return (l, p, s, c) -> dev.hyperlynx.reactive.be.CrucibleBlockEntity.tick(l, p, s, (dev.hyperlynx.reactive.be.CrucibleBlockEntity) c);
        }
        return null;

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
@@ -1,0 +1,38 @@
+package dev.hyperlynx.reactive.blocks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.Portal;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.portal.DimensionTransition;
+import org.jetbrains.annotations.Nullable;
+
+public class GatewayBlock extends Block implements Portal, EntityBlock {
+    public GatewayBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public @Nullable BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
+        return null;
+    }
+
+    @Override
+    public int getPortalTransitionTime(ServerLevel level, Entity entity) {
+        return Portal.super.getPortalTransitionTime(level, entity);
+    }
+
+    @Override
+    public @Nullable DimensionTransition getPortalDestination(ServerLevel serverLevel, Entity entity, BlockPos blockPos) {
+        return null;
+    }
+
+    @Override
+    public Transition getLocalTransition() {
+        return Portal.super.getLocalTransition();
+    }
+}

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
@@ -5,6 +5,7 @@ import dev.hyperlynx.reactive.be.GatewayBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
@@ -15,10 +16,15 @@ import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.DimensionTransition;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class GatewayBlock extends Block implements Portal, EntityBlock {
+    private final VoxelShape SHAPE = Block.box(6, 6, 6, 10, 10, 10);
+
     public GatewayBlock(Properties properties) {
         super(properties);
     }
@@ -51,5 +57,10 @@ public class GatewayBlock extends Block implements Portal, EntityBlock {
     @Override
     public @NotNull RenderShape getRenderShape(@NotNull BlockState state) {
         return RenderShape.ENTITYBLOCK_ANIMATED;
+    }
+
+    @Override
+    protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return SHAPE;
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
@@ -1,14 +1,17 @@
 package dev.hyperlynx.reactive.blocks;
 
+import dev.hyperlynx.reactive.be.GatewayBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.Portal;
+import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.DimensionTransition;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class GatewayBlock extends Block implements Portal, EntityBlock {
@@ -17,12 +20,12 @@ public class GatewayBlock extends Block implements Portal, EntityBlock {
     }
 
     @Override
-    public @Nullable BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
-        return null;
+    public @Nullable BlockEntity newBlockEntity(@NotNull BlockPos pos, @NotNull BlockState state) {
+        return new GatewayBlockEntity(pos, state);
     }
 
     @Override
-    public int getPortalTransitionTime(ServerLevel level, Entity entity) {
+    public int getPortalTransitionTime(@NotNull ServerLevel level, @NotNull Entity entity) {
         return Portal.super.getPortalTransitionTime(level, entity);
     }
 
@@ -34,5 +37,10 @@ public class GatewayBlock extends Block implements Portal, EntityBlock {
     @Override
     public Transition getLocalTransition() {
         return Portal.super.getLocalTransition();
+    }
+
+    @Override
+    public @NotNull RenderShape getRenderShape(@NotNull BlockState state) {
+        return RenderShape.ENTITYBLOCK_ANIMATED;
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class GatewayBlock extends Block implements Portal, EntityBlock {
-    private final VoxelShape SHAPE = Block.box(6, 6, 6, 10, 10, 10);
+    private final VoxelShape SHAPE = Block.box(5, 5, 5, 11, 11, 11);
 
     public GatewayBlock(Properties properties) {
         super(properties);

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
@@ -1,10 +1,14 @@
 package dev.hyperlynx.reactive.blocks;
 
+import dev.hyperlynx.reactive.ConfigMan;
+import dev.hyperlynx.reactive.ReactiveMod;
 import dev.hyperlynx.reactive.Registration;
 import dev.hyperlynx.reactive.be.GatewayBlockEntity;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -16,6 +20,7 @@ import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.DimensionTransition;
+import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -45,8 +50,26 @@ public class GatewayBlock extends Block implements Portal, EntityBlock {
     }
 
     @Override
-    public @Nullable DimensionTransition getPortalDestination(ServerLevel serverLevel, Entity entity, BlockPos blockPos) {
+    public @Nullable DimensionTransition getPortalDestination(ServerLevel level, Entity entity, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if(be instanceof GatewayBlockEntity gateway && gateway.target != null) {
+            ServerLevel target_level = level.getServer().getLevel(gateway.target.dimension());
+            if(target_level == null){
+                ReactiveMod.LOGGER.error("Invalid destination dimension for gateway!");
+                return null;
+            }
+            return new DimensionTransition(target_level, Vec3.atCenterOf(gateway.target.pos()), entity.getDeltaMovement(), entity.getYRot(), entity.getXRot(), DimensionTransition.DO_NOTHING);
+        }
+        ReactiveMod.LOGGER.error("No destination set for gateway!");
         return null;
+    }
+
+    @Override
+    protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity) {
+        super.entityInside(state, level, pos, entity);
+        if (!ConfigMan.COMMON.doNotTeleport.get().contains(entity.getEncodeId())) {
+            entity.setAsInsidePortal(this, pos);
+        }
     }
 
     @Override
@@ -62,5 +85,10 @@ public class GatewayBlock extends Block implements Portal, EntityBlock {
     @Override
     protected VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
         return SHAPE;
+    }
+
+    @Override
+    protected void spawnDestroyParticles(Level level, Player player, BlockPos pos, BlockState state) {
+        // NO-OP
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayBlock.java
@@ -1,14 +1,18 @@
 package dev.hyperlynx.reactive.blocks;
 
+import dev.hyperlynx.reactive.Registration;
 import dev.hyperlynx.reactive.be.GatewayBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.Portal;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.portal.DimensionTransition;
 import org.jetbrains.annotations.NotNull;
@@ -17,6 +21,11 @@ import org.jetbrains.annotations.Nullable;
 public class GatewayBlock extends Block implements Portal, EntityBlock {
     public GatewayBlock(Properties properties) {
         super(properties);
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
+        return type == Registration.GATEWAY_BE.get() ? GatewayBlockEntity::tick : null;
     }
 
     @Override

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayPlinthBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayPlinthBlock.java
@@ -4,6 +4,7 @@ import dev.hyperlynx.reactive.ReactiveMod;
 import dev.hyperlynx.reactive.Registration;
 import dev.hyperlynx.reactive.alchemy.Powers;
 import dev.hyperlynx.reactive.alchemy.rxn.ReactionEffects;
+import dev.hyperlynx.reactive.be.GatewayBlockEntity;
 import dev.hyperlynx.reactive.client.particles.ParticleScribe;
 import dev.hyperlynx.reactive.items.WarpBottleItem;
 import net.minecraft.advancements.Advancement;
@@ -67,7 +68,7 @@ public class GatewayPlinthBlock extends Block {
 
     @Override
     protected void neighborChanged(BlockState state, Level level, BlockPos pos, Block pNeighborBlock, BlockPos pNeighborPos, boolean pMovedByPiston) {
-        if(state.getValue(ACTIVE) && !level.getBlockState(pos.above()).is(Blocks.END_GATEWAY)){
+        if(state.getValue(ACTIVE) && !level.getBlockState(pos.above()).is(Registration.GATEWAY_BLOCK.get())){
             level.setBlock(pos, state.setValue(ACTIVE, false), Block.UPDATE_CLIENTS);
         }
         super.neighborChanged(state, level, pos, pNeighborBlock, pNeighborPos, pMovedByPiston);
@@ -82,16 +83,12 @@ public class GatewayPlinthBlock extends Block {
                     player.displayClientMessage(Component.translatable("message.reactive.activate_plinth_failed"), true);
                     return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
                 }
-                if(level.dimension().equals(warp_target.dimension())){
-                    setGateway(level, pos.above(), warp_target.pos(), state);
-                    level.playSound((Player) null, pos, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS);
-                    level.playSound((Player) null, pos, SoundEvents.EVOKER_CAST_SPELL, SoundSource.BLOCKS, 0.9F, 0.75F);
-                    level.playSound((Player) null, pos, SoundEvents.BELL_RESONATE, SoundSource.BLOCKS, 0.3F, 1F);
-                    player.setItemInHand(hand, Registration.QUARTZ_BOTTLE.get().getDefaultInstance());
-                    return ItemInteractionResult.SUCCESS;
-                }
-                player.displayClientMessage(Component.translatable("message.reactive.activate_plinth_failed"), true);
-                return ItemInteractionResult.FAIL;
+                setGateway(level, pos.above(), warp_target, state);
+                level.playSound((Player) null, pos, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS);
+                level.playSound((Player) null, pos, SoundEvents.EVOKER_CAST_SPELL, SoundSource.BLOCKS, 0.9F, 0.75F);
+                level.playSound((Player) null, pos, SoundEvents.BELL_RESONATE, SoundSource.BLOCKS, 0.3F, 1F);
+                player.setItemInHand(hand, Registration.QUARTZ_BOTTLE.get().getDefaultInstance());
+                return ItemInteractionResult.SUCCESS;
             }
 
             if (player instanceof ServerPlayer splayer) {
@@ -106,20 +103,20 @@ public class GatewayPlinthBlock extends Block {
         return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
     }
 
-    private static void setGateway(Level level, BlockPos source, BlockPos destination, BlockState self_state){
+    private static void setGateway(Level level, BlockPos source, GlobalPos destination, BlockState self_state){
         level.setBlock(source.below(), self_state.setValue(ACTIVE, true), Block.UPDATE_CLIENTS);
-        level.setBlock(source, Blocks.END_GATEWAY.defaultBlockState(), Block.UPDATE_CLIENTS);
+        level.setBlock(source, Registration.GATEWAY_BLOCK.get().defaultBlockState(), Block.UPDATE_CLIENTS);
         var be = level.getBlockEntity(source);
-        if(!(be instanceof TheEndGatewayBlockEntity gateway)){
+        if(!(be instanceof GatewayBlockEntity gateway)){
             return;
         }
-        gateway.setExitPosition(destination, true);
+        gateway.target = destination;
     }
 
     @Override
     protected void onRemove(BlockState state, Level level, BlockPos pos, BlockState new_state, boolean moved_by_piston) {
         if(state.getValue(ACTIVE)){
-            if(level.getBlockState(pos.above()).is(Blocks.END_GATEWAY)){
+            if(level.getBlockState(pos.above()).is(Registration.GATEWAY_BLOCK.get())){
                 level.removeBlock(pos.above(), false);
                 Vec3 rift_pos  = Vec3.atCenterOf(pos.above());
                 for(BlockPos point : ReactionEffects.getCreationPoints(pos)){

--- a/src/main/java/dev/hyperlynx/reactive/blocks/GatewayPlinthBlock.java
+++ b/src/main/java/dev/hyperlynx/reactive/blocks/GatewayPlinthBlock.java
@@ -14,12 +14,14 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
@@ -28,6 +30,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.SimpleExplosionDamageCalculator;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.TheEndGatewayBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -68,10 +71,21 @@ public class GatewayPlinthBlock extends Block {
 
     @Override
     protected void neighborChanged(BlockState state, Level level, BlockPos pos, Block pNeighborBlock, BlockPos pNeighborPos, boolean pMovedByPiston) {
+        if(level instanceof ServerLevel slevel && level.getBlockState(pos.above()).is(Blocks.END_GATEWAY)){
+            convertEndGateway(slevel, pos.above());
+            level.setBlock(pos, state.setValue(ACTIVE, true), Block.UPDATE_CLIENTS);
+        }
         if(state.getValue(ACTIVE) && !level.getBlockState(pos.above()).is(Registration.GATEWAY_BLOCK.get())){
             level.setBlock(pos, state.setValue(ACTIVE, false), Block.UPDATE_CLIENTS);
         }
         super.neighborChanged(state, level, pos, pNeighborBlock, pNeighborPos, pMovedByPiston);
+    }
+
+    @Override
+    protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity) {
+        if(level instanceof ServerLevel slevel && level.getBlockState(pos.above()).is(Blocks.END_GATEWAY)){
+            convertEndGateway(slevel, pos.above());
+        }
     }
 
     @Override
@@ -126,5 +140,27 @@ public class GatewayPlinthBlock extends Block {
             }
         }
         super.onRemove(state, level, pos, new_state, moved_by_piston);
+    }
+
+    // For old worlds, we need to be able to change existing End Gateways into Reactive Gateway blocks.
+    // This method does that. Pass it the position of the gateway.
+    private static void convertEndGateway(ServerLevel level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if(!(be instanceof TheEndGatewayBlockEntity end_gateway)) {
+            ReactiveMod.LOGGER.error("Tried to convert an inconvertible block at {}.", pos);
+            return;
+        }
+        Vec3 target_vector = end_gateway.getPortalPosition(level, pos);
+        if(target_vector == null){
+            ReactiveMod.LOGGER.error("No valid destination for the end gateway at {}.", pos);
+            return;
+        }
+        level.setBlock(pos, Registration.GATEWAY_BLOCK.get().defaultBlockState(), Block.UPDATE_CLIENTS);
+        BlockEntity be2 = level.getBlockEntity(pos);
+        if(!(be2 instanceof GatewayBlockEntity gateway)) {
+            ReactiveMod.LOGGER.error("Something went wrong while converting the gateway at {}.", pos);
+            return;
+        }
+        gateway.target = GlobalPos.of(level.dimension(), BlockPos.containing(target_vector));
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/client/ClientRegistration.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/ClientRegistration.java
@@ -3,6 +3,7 @@ package dev.hyperlynx.reactive.client;
 import dev.hyperlynx.reactive.Registration;
 import dev.hyperlynx.reactive.client.particles.*;
 import dev.hyperlynx.reactive.client.renderers.CrucibleRenderer;
+import dev.hyperlynx.reactive.client.renderers.GatewayRenderer;
 import dev.hyperlynx.reactive.client.renderers.SymbolRenderer;
 import net.minecraft.client.Minecraft;
 import net.neoforged.bus.api.IEventBus;
@@ -27,8 +28,9 @@ public class ClientRegistration {
 
     @SubscribeEvent
     public static void registerBlockEntityRenderers(EntityRenderersEvent.RegisterRenderers evt) {
-        evt.registerBlockEntityRenderer(Registration.CRUCIBLE_BE_TYPE.get(), CrucibleRenderer::new);
-        evt.registerBlockEntityRenderer(Registration.SYMBOL_BE_TYPE.get(), SymbolRenderer::new);
+        evt.registerBlockEntityRenderer(Registration.CRUCIBLE_BE.get(), CrucibleRenderer::new);
+        evt.registerBlockEntityRenderer(Registration.SYMBOL_BE.get(), SymbolRenderer::new);
+        evt.registerBlockEntityRenderer(Registration.GATEWAY_BE.get(), GatewayRenderer::new);
     }
 
     @SubscribeEvent

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -7,6 +7,7 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.core.Direction;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
 
@@ -26,14 +27,18 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
     private void renderCube(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
         double time = gateway.totalTick(partialTick);
         float distortion = (float) (Math.sin(time / 50) * 0.03 + 0.04);
-        float distortion2 = (float) (Math.sin(time / 75) * 0.03 + 0.04);
 
-        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion);
-        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion);
-        this.renderFace(pose, consumer, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
-        this.renderFace(pose, consumer, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
-        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion);
-        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion);
+        // SOUTH, NORTH
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F , 1.0F, 1.0F, 1.0F);
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F);
+
+        // EAST, WEST
+        this.renderFace(pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F);
+        this.renderFace(pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F);
+
+        // DOWN, UP
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F);
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F);
     }
 
     private void renderFace(Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3) {

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -27,25 +27,31 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
     private void renderCube(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
         double time = gateway.totalTick(partialTick);
         float distortion_1 = (float) (Math.sin(time / 50) * 0.03 + 0.95);
-        float distortion_2 = (float) (Math.sin(time / 51) * 0.03 + 0.95);
+        float distortion_2 = (float) (Math.sin(time / 55) * 0.03 + 0.95);
+        float distortion_3 = (float) (Math.sin(time / 48) * 0.032 + 0.95);
+        float distortion_4 = (float) (Math.sin(time / 52) * 0.032 + 0.95);
+        float distortion_5 = (float) (Math.sin((time / 50) + 0.5) * 0.03 + 0.95);
+        float distortion_6 = (float) (Math.sin((time / 55) + 0.5) * 0.03 + 0.95);
+        float distortion_7 = (float) (Math.sin((time / 48) + 0.5) * 0.032 + 0.95);
+        float distortion_8 = (float) (Math.sin((time / 52) + 0.5) * 0.032 + 0.95);
 
         // SOUTH, NORTH
         this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F , 1.0F, 1.0F, 1.0F,
-                1.0F, distortion_1, 1.0F, distortion_2);
+                distortion_3, distortion_1, distortion_4, distortion_2);
         this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
                 1.0F, 1.0F, 1.0F, 1.0F);
 
         // EAST, WEST
         this.renderFace(pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F,
-                1.0F, 1.0F, distortion_2, 1.0F);
+                1.0F, 1.0F, distortion_2, distortion_4);
         this.renderFace(pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F,
-                1.0F, 1.0F, 1.0F, distortion_1);
+                1.0F, 1.0F, distortion_3, distortion_1);
 
         // DOWN, UP
         this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F,
                 distortion_1, 1.0F, distortion_2, 1.0F);
         this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F,
-                1.0F, 1.0F, 1.0F, 1.0F);
+                1.0F, distortion_3, 1.0F, distortion_4);
     }
 
     private void renderFace(Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3, float ul_distort, float dl_distort, float ur_distort, float dr_distort) {

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -1,0 +1,44 @@
+package dev.hyperlynx.reactive.client.renderers;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import dev.hyperlynx.reactive.be.GatewayBlockEntity;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.core.Direction;
+import org.joml.Matrix4f;
+
+// Duplicated from TheEndPortalRenderer
+public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntityRenderer<GatewayBlockEntity> {
+    public void render(GatewayBlockEntity gateway, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
+        Matrix4f matrix4f = poseStack.last().pose();
+        this.renderCube(gateway, matrix4f, bufferSource.getBuffer(RenderType.END_GATEWAY));
+    }
+
+    private void renderCube(GatewayBlockEntity gateway, Matrix4f pose, VertexConsumer consumer) {
+        float f = this.getOffsetDown();
+        float f1 = this.getOffsetUp();
+        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, Direction.SOUTH);
+        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, Direction.NORTH);
+        this.renderFace(gateway, pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F, Direction.EAST);
+        this.renderFace(gateway, pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F, Direction.WEST);
+        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, f, f, 0.0F, 0.0F, 1.0F, 1.0F, Direction.DOWN);
+        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, f1, f1, 1.0F, 1.0F, 0.0F, 0.0F, Direction.UP);
+    }
+
+    private void renderFace(GatewayBlockEntity gateway, Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3, Direction direction) {
+        consumer.addVertex(pose, x0, y0, z0);
+        consumer.addVertex(pose, x1, y0, z1);
+        consumer.addVertex(pose, x1, y1, z2);
+        consumer.addVertex(pose, x0, y1, z3);
+    }
+
+    protected float getOffsetUp() {
+        return 0.75F;
+    }
+
+    protected float getOffsetDown() {
+        return 0.375F;
+    }
+}

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -25,7 +25,7 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
 
     private void renderVolume(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
         double time = gateway.totalTick(partialTick);
-        float amplitude = 0.15F;
+        float amplitude = 0.12F;
         float distortion_1 = (float) (Math.sin(time / 50) * amplitude + 0.95);
         float distortion_2 = (float) (Math.sin(time / 55) * amplitude + 0.95);
         float distortion_3 = (float) (Math.sin(time / 48) * amplitude + 0.95);

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -1,27 +1,48 @@
 package dev.hyperlynx.reactive.client.renderers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import dev.hyperlynx.reactive.be.GatewayBlockEntity;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.blockentity.TheEndPortalRenderer;
+import net.minecraft.core.Direction;
+import org.jetbrains.annotations.NotNull;
+import org.joml.Matrix4f;
 
-// Duplicated from TheEndPortalRenderer
-public class GatewayRenderer<T extends GatewayBlockEntity> extends TheEndPortalRenderer<T> {
+import static java.lang.Math.sin;
+
+// Adapted from TheEndPortalRenderer
+public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntityRenderer<T> {
+    BlockEntityRendererProvider.Context context;
+
     public GatewayRenderer(BlockEntityRendererProvider.Context context) {
-        super(context);
+        this.context = context;
     }
 
-    @Override
-    public void render(T blockEntity, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
-        super.render(blockEntity, partialTick, poseStack, bufferSource, packedLight, packedOverlay);
+    public void render(@NotNull T gateway, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
+        Matrix4f matrix4f = poseStack.last().pose();
+        this.renderCube(gateway, matrix4f, bufferSource.getBuffer(RenderType.END_GATEWAY), partialTick);
     }
 
-    protected float getOffsetUp() {
-        return 1F;
+    private void renderCube(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
+        double time = gateway.totalTick(partialTick);
+        float distortion = (float) (Math.sin(time / 25) * 0.02);
+
+        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion);
+        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion);
+        this.renderFace(gateway, pose, consumer, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
+        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
+        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion);
+        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion);
     }
 
-    protected float getOffsetDown() {
-        return 0F;
+    private void renderFace(T gateway, Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3) {
+        consumer.addVertex(pose, x0, y0, z0);
+        consumer.addVertex(pose, x1, y0, z1);
+        consumer.addVertex(pose, x1, y1, z2);
+        consumer.addVertex(pose, x0, y1, z3);
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -1,44 +1,27 @@
 package dev.hyperlynx.reactive.client.renderers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import dev.hyperlynx.reactive.be.GatewayBlockEntity;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
-import net.minecraft.core.Direction;
-import org.joml.Matrix4f;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.TheEndPortalRenderer;
 
 // Duplicated from TheEndPortalRenderer
-public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntityRenderer<GatewayBlockEntity> {
-    public void render(GatewayBlockEntity gateway, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
-        Matrix4f matrix4f = poseStack.last().pose();
-        this.renderCube(gateway, matrix4f, bufferSource.getBuffer(RenderType.END_GATEWAY));
+public class GatewayRenderer<T extends GatewayBlockEntity> extends TheEndPortalRenderer<T> {
+    public GatewayRenderer(BlockEntityRendererProvider.Context context) {
+        super(context);
     }
 
-    private void renderCube(GatewayBlockEntity gateway, Matrix4f pose, VertexConsumer consumer) {
-        float f = this.getOffsetDown();
-        float f1 = this.getOffsetUp();
-        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, Direction.SOUTH);
-        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, Direction.NORTH);
-        this.renderFace(gateway, pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F, Direction.EAST);
-        this.renderFace(gateway, pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F, Direction.WEST);
-        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, f, f, 0.0F, 0.0F, 1.0F, 1.0F, Direction.DOWN);
-        this.renderFace(gateway, pose, consumer, 0.0F, 1.0F, f1, f1, 1.0F, 1.0F, 0.0F, 0.0F, Direction.UP);
-    }
-
-    private void renderFace(GatewayBlockEntity gateway, Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3, Direction direction) {
-        consumer.addVertex(pose, x0, y0, z0);
-        consumer.addVertex(pose, x1, y0, z1);
-        consumer.addVertex(pose, x1, y1, z2);
-        consumer.addVertex(pose, x0, y1, z3);
+    @Override
+    public void render(T blockEntity, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
+        super.render(blockEntity, partialTick, poseStack, bufferSource, packedLight, packedOverlay);
     }
 
     protected float getOffsetUp() {
-        return 0.75F;
+        return 1F;
     }
 
     protected float getOffsetDown() {
-        return 0.375F;
+        return 0F;
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -29,22 +29,34 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
         float distortion = (float) (Math.sin(time / 50) * 0.03 + 0.04);
 
         // SOUTH, NORTH
-        this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F , 1.0F, 1.0F, 1.0F);
-        this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F);
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F , 1.0F, 1.0F, 1.0F,
+                1.0F, 0.9F, 1.0F, 1.0F);
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
+                1.0F, 1.0F, 1.0F, 1.0F);
 
         // EAST, WEST
-        this.renderFace(pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F);
-        this.renderFace(pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F);
+        this.renderFace(pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F,
+                1.0F, 1.0F, 1.0F, 1.0F);
+        this.renderFace(pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F,
+                1.0F, 1.0F, 1.0F, 0.9F);
 
         // DOWN, UP
-        this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F);
-        this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F);
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F,
+                0.9F, 1.0F, 1.0F, 1.0F);
+        this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F,
+                1.0F, 1.0F, 1.0F, 1.0F);
     }
 
-    private void renderFace(Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3) {
-        consumer.addVertex(pose, x0, y0, z0);
-        consumer.addVertex(pose, x1, y0, z1);
-        consumer.addVertex(pose, x1, y1, z2);
-        consumer.addVertex(pose, x0, y1, z3);
+    private void renderFace(Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3, float ul_distort, float dl_distort, float ur_distort, float dr_distort) {
+        consumer.addVertex(pose, adjust(x0, dl_distort), adjust(y0,  dl_distort), adjust(z0, dl_distort));
+        consumer.addVertex(pose, adjust(x1,  dr_distort), adjust(y0,  dr_distort), adjust(z1, dr_distort));
+        consumer.addVertex(pose, adjust(x1,  ur_distort), adjust(y1,  ur_distort), adjust(z2, ur_distort));
+        consumer.addVertex(pose, adjust(x0,  ul_distort), adjust(y1,  ul_distort), adjust(z3, ul_distort));
+    }
+
+    private float adjust(float base, float distort_factor){
+        float core_dist = base - 0.5F;
+        float result_dist = core_dist * distort_factor;
+        return result_dist + 0.5F;
     }
 }

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -25,7 +25,7 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
 
     private void renderVolume(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
         double time = gateway.totalTick(partialTick);
-        float amplitude = 0.1F;
+        float amplitude = 0.15F;
         float distortion_1 = (float) (Math.sin(time / 50) * amplitude + 0.95);
         float distortion_2 = (float) (Math.sin(time / 55) * amplitude + 0.95);
         float distortion_3 = (float) (Math.sin(time / 48) * amplitude + 0.95);

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -7,7 +7,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import net.minecraft.core.Direction;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
 
@@ -21,37 +20,38 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
 
     public void render(@NotNull T gateway, float partialTick, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
         Matrix4f matrix4f = poseStack.last().pose();
-        this.renderCube(gateway, matrix4f, bufferSource.getBuffer(RenderType.END_GATEWAY), partialTick);
+        this.renderVolume(gateway, matrix4f, bufferSource.getBuffer(RenderType.END_GATEWAY), partialTick);
     }
 
-    private void renderCube(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
+    private void renderVolume(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
         double time = gateway.totalTick(partialTick);
-        float distortion_1 = (float) (Math.sin(time / 50) * 0.03 + 0.95);
-        float distortion_2 = (float) (Math.sin(time / 55) * 0.03 + 0.95);
-        float distortion_3 = (float) (Math.sin(time / 48) * 0.032 + 0.95);
-        float distortion_4 = (float) (Math.sin(time / 52) * 0.032 + 0.95);
-        float distortion_5 = (float) (Math.sin((time / 50) + 0.5) * 0.03 + 0.95);
-        float distortion_6 = (float) (Math.sin((time / 55) + 0.5) * 0.03 + 0.95);
-        float distortion_7 = (float) (Math.sin((time / 48) + 0.5) * 0.032 + 0.95);
-        float distortion_8 = (float) (Math.sin((time / 52) + 0.5) * 0.032 + 0.95);
+        float amplitude = 0.1F;
+        float distortion_1 = (float) (Math.sin(time / 50) * amplitude + 0.95);
+        float distortion_2 = (float) (Math.sin(time / 55) * amplitude + 0.95);
+        float distortion_3 = (float) (Math.sin(time / 48) * amplitude + 0.95);
+        float distortion_4 = (float) (Math.sin(time / 52) * amplitude + 0.95);
+        float distortion_5 = (float) (Math.sin((time / 50) + 0.5) * amplitude + 0.95);
+        float distortion_6 = (float) (Math.sin((time / 55) + 0.5) * amplitude + 0.95);
+        float distortion_7 = (float) (Math.sin((time / 48) + 0.5) * amplitude + 0.95);
+        float distortion_8 = (float) (Math.sin((time / 52) + 0.5) * amplitude + 0.95);
 
         // SOUTH, NORTH
         this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F , 1.0F, 1.0F, 1.0F,
                 distortion_3, distortion_1, distortion_4, distortion_2);
         this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
-                1.0F, 1.0F, 1.0F, 1.0F);
+                distortion_7, distortion_5, distortion_6, distortion_8);
 
         // EAST, WEST
         this.renderFace(pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F,
-                1.0F, 1.0F, distortion_2, distortion_4);
+                distortion_6, distortion_8, distortion_2, distortion_4);
         this.renderFace(pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F,
-                1.0F, 1.0F, distortion_3, distortion_1);
+                distortion_5, distortion_7, distortion_3, distortion_1);
 
         // DOWN, UP
         this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F,
-                distortion_1, 1.0F, distortion_2, 1.0F);
+                distortion_1, distortion_7, distortion_2, distortion_6);
         this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F,
-                1.0F, distortion_3, 1.0F, distortion_4);
+                distortion_5, distortion_3, distortion_8, distortion_4);
     }
 
     private void renderFace(Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3, float ul_distort, float dl_distort, float ur_distort, float dr_distort) {

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -26,23 +26,24 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
 
     private void renderCube(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
         double time = gateway.totalTick(partialTick);
-        float distortion = (float) (Math.sin(time / 50) * 0.03 + 0.04);
+        float distortion_1 = (float) (Math.sin(time / 50) * 0.03 + 0.95);
+        float distortion_2 = (float) (Math.sin(time / 51) * 0.03 + 0.95);
 
         // SOUTH, NORTH
         this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F , 1.0F, 1.0F, 1.0F,
-                1.0F, 0.9F, 1.0F, 1.0F);
+                1.0F, distortion_1, 1.0F, distortion_2);
         this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
                 1.0F, 1.0F, 1.0F, 1.0F);
 
         // EAST, WEST
         this.renderFace(pose, consumer, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F,
-                1.0F, 1.0F, 1.0F, 1.0F);
+                1.0F, 1.0F, distortion_2, 1.0F);
         this.renderFace(pose, consumer, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F,
-                1.0F, 1.0F, 1.0F, 0.9F);
+                1.0F, 1.0F, 1.0F, distortion_1);
 
         // DOWN, UP
         this.renderFace(pose, consumer, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 1.0F,
-                0.9F, 1.0F, 1.0F, 1.0F);
+                distortion_1, 1.0F, distortion_2, 1.0F);
         this.renderFace(pose, consumer, 0.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 0.0F, 0.0F,
                 1.0F, 1.0F, 1.0F, 1.0F);
     }

--- a/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
+++ b/src/main/java/dev/hyperlynx/reactive/client/renderers/GatewayRenderer.java
@@ -7,12 +7,8 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import net.minecraft.client.renderer.blockentity.TheEndPortalRenderer;
-import net.minecraft.core.Direction;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
-
-import static java.lang.Math.sin;
 
 // Adapted from TheEndPortalRenderer
 public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntityRenderer<T> {
@@ -29,17 +25,18 @@ public class GatewayRenderer<T extends GatewayBlockEntity> implements BlockEntit
 
     private void renderCube(T gateway, Matrix4f pose, VertexConsumer consumer, float partialTick) {
         double time = gateway.totalTick(partialTick);
-        float distortion = (float) (Math.sin(time / 25) * 0.02);
+        float distortion = (float) (Math.sin(time / 50) * 0.03 + 0.04);
+        float distortion2 = (float) (Math.sin(time / 75) * 0.03 + 0.04);
 
-        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion);
-        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion);
-        this.renderFace(gateway, pose, consumer, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
-        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
-        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion);
-        this.renderFace(gateway, pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion);
+        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion);
+        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion);
+        this.renderFace(pose, consumer, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
+        this.renderFace(pose, consumer, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion);
+        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion);
+        this.renderFace(pose, consumer, 0.0F + distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 1.0F - distortion, 0.0F + distortion, 0.0F + distortion);
     }
 
-    private void renderFace(T gateway, Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3) {
+    private void renderFace(Matrix4f pose, VertexConsumer consumer, float x0, float x1, float y0, float y1, float z0, float z1, float z2, float z3) {
         consumer.addVertex(pose, x0, y0, z0);
         consumer.addVertex(pose, x1, y0, z1);
         consumer.addVertex(pose, x1, y1, z2);

--- a/src/main/resources/assets/reactive/blockstates/gateway.json
+++ b/src/main/resources/assets/reactive/blockstates/gateway.json
@@ -1,0 +1,9 @@
+{
+  "multipart": [
+    {
+      "apply": {
+        "model": "reactive:block/iron_symbol_placeholder"
+      }
+    }
+  ]
+}

--- a/src/main/resources/assets/reactive/patchouli_books/journal/en_us/entries/items/rending_plinth.json
+++ b/src/main/resources/assets/reactive/patchouli_books/journal/en_us/entries/items/rending_plinth.json
@@ -11,7 +11,7 @@
     },
     {
       "type": "patchouli:text",
-      "text": "$(6)Once you have the bottle in hand, pour it out onto the Plinth. This will capture and expand the Rift inside it into an infinitely traversable portal to the Bottle's destination. $(p)The Rift will persist so long as the Plinth is not moved."
+      "text": "$(6)Once you have the bottle in hand, pour it out onto the Plinth. This will capture and expand the Rift inside it into an infinitely traversable portal to the Bottle's destination, even across dimensions. $(p)The Rift will persist so long as the Plinth is not moved."
     }
   ]
 }

--- a/src/main/resources/data/reactive/recipe/transmutation/rending_plinth.json
+++ b/src/main/resources/data/reactive/recipe/transmutation/rending_plinth.json
@@ -1,7 +1,7 @@
 {
   "type": "reactive:transmutation",
   "reactant": {
-    "item": "minecraft:lodestone"
+    "item": "reactive:runestone"
   },
   "product": {
     "id": "reactive:rending_plinth"


### PR DESCRIPTION
This changelist allows the Rending Plinth's portals to connect across dimensions, and gives them a very nice new animated appearance. Old portals will automatically be converted upon their first use.